### PR TITLE
稍稍优化下消息类型解析方法，抽象推拉消费者中的公共代码

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <java.version>1.8</java.version>
-        <rocketmq.version>4.0.0-incubating</rocketmq.version>
+        <rocketmq.version>4.1.0-incubating</rocketmq.version>
         <file_encoding>UTF-8</file_encoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <java.version>1.8</java.version>
-        <rocketmq.version>4.1.0-incubating</rocketmq.version>
+        <rocketmq.version>4.0.0-incubating</rocketmq.version>
         <file_encoding>UTF-8</file_encoding>
     </properties>
 

--- a/src/main/java/com/maihaoche/starter/mq/base/AbstractMQConsumer.java
+++ b/src/main/java/com/maihaoche/starter/mq/base/AbstractMQConsumer.java
@@ -1,0 +1,67 @@
+package com.maihaoche.starter.mq.base;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.springframework.util.Assert;
+
+/**
+ * Comments：RocketMQ消费抽象基类
+ * Author：Jay Chang
+ * Create Date：2017/9/14
+ * Modified By：
+ * Modified Date：
+ * Why & What is modified：
+ * Version：v1.0
+ */
+@Slf4j
+public abstract class AbstractMQConsumer<T> {
+
+    protected static Gson gson = new Gson();
+
+    /**
+     * 反序列化解析消息
+     *
+     * @param message  消息体
+     * @return 序列化结果
+     */
+    protected T parseMessage(MessageExt message) {
+        if (message == null || message.getBody() == null) {
+            return null;
+        }
+        final Type type = this.getMessageType();
+        if (type instanceof Class) {
+            try {
+                T data = gson.fromJson(new String(message.getBody()), type);
+                return data;
+            } catch (JsonSyntaxException e) {
+                log.error("parse message json fail : {}", e.getMessage());
+            }
+        } else {
+            log.warn("Parse msg error. {}", message);
+        }
+        return null;
+    }
+
+    /**
+     * 解析消息类型
+     *
+     * @return 消息类型
+     */
+    protected Type getMessageType() {
+        Type superType = this.getClass().getGenericSuperclass();
+        if (superType instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) superType;
+            Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+            Assert.isTrue(actualTypeArguments.length == 1, "Number of type arguments must be 1");
+            return actualTypeArguments[0];
+        } else {
+            // 如果没有定义泛型，解析为Object
+            return Object.class;
+//            throw new RuntimeException("Unkown parameterized type.");
+        }
+    }
+}

--- a/src/main/java/com/maihaoche/starter/mq/base/AbstractMQPullConsumer.java
+++ b/src/main/java/com/maihaoche/starter/mq/base/AbstractMQPullConsumer.java
@@ -1,24 +1,19 @@
 package com.maihaoche.starter.mq.base;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
+import java.util.List;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Set;
-
 /**
  * Created by yipin on 2017/6/27.
  * RocketMQ的消费者(Push模式)处理消息的接口
  */
 @Slf4j
-public abstract class AbstractMQPullConsumer<T> {
+public abstract class AbstractMQPullConsumer<T> extends AbstractMQConsumer<T>{
 
     public AbstractMQPullConsumer() {
     }
@@ -81,9 +76,6 @@ public abstract class AbstractMQPullConsumer<T> {
         }).start();
     }
 
-
-    private static Gson gson = new Gson();
-
     /**
      * 继承这个方法处理消息
      *
@@ -104,46 +96,6 @@ public abstract class AbstractMQPullConsumer<T> {
             log.info("receive msgId: {}, tags : {}" , messageExt.getMsgId(), messageExt.getTags());
             T t = parseMessage(messageExt);
             process(t);
-        }
-    }
-
-    /**
-     * 反序列化解析消息
-     *
-     * @param message  消息体
-     * @return 序列化结果
-     */
-    private T parseMessage(MessageExt message) {
-        if (message == null || message.getBody() == null) {
-            return null;
-        }
-        final Type type = this.getMessageType();
-        if (type instanceof Class) {
-            try {
-                Object data = gson.fromJson(new String(message.getBody()), type);
-                return (T) data;
-            } catch (JsonSyntaxException e) {
-                log.error("parse message json fail : {}", e.getMessage());
-            }
-        } else {
-            log.warn("Parse msg error. {}", message);
-        }
-        return null;
-    }
-
-    /**
-     * 解析消息类型
-     *
-     * @return 消息类型
-     */
-    private Type getMessageType() {
-        Type superType = this.getClass().getGenericSuperclass();
-        if (superType instanceof ParameterizedType) {
-            return ((ParameterizedType) superType).getActualTypeArguments()[0];
-        } else {
-            // 如果没有定义泛型，解析为Object
-            return Object.class;
-//            throw new RuntimeException("Unkown parameterized type.");
         }
     }
 }

--- a/src/main/java/com/maihaoche/starter/mq/base/AbstractMQPushConsumer.java
+++ b/src/main/java/com/maihaoche/starter/mq/base/AbstractMQPushConsumer.java
@@ -1,7 +1,6 @@
 package com.maihaoche.starter.mq.base;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -12,16 +11,12 @@ import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
 import org.apache.rocketmq.common.message.MessageExt;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.List;
-
 /**
  * Created by yipin on 2017/6/27.
  * RocketMQ的消费者(Push模式)处理消息的接口
  */
 @Slf4j
-public abstract class AbstractMQPushConsumer<T> {
+public abstract class AbstractMQPushConsumer<T> extends AbstractMQConsumer<T>{
 
     @Getter
     @Setter
@@ -29,8 +24,6 @@ public abstract class AbstractMQPushConsumer<T> {
 
     public AbstractMQPushConsumer() {
     }
-
-    private static Gson gson = new Gson();
 
     /**
      * 继承这个方法处理消息
@@ -83,45 +76,5 @@ public abstract class AbstractMQPushConsumer<T> {
             }
         }
         return  ConsumeOrderlyStatus.SUCCESS;
-    }
-
-    /**
-     * 反序列化解析消息
-     *
-     * @param message  消息体
-     * @return 反序列化结果
-     */
-    private T parseMessage(MessageExt message) {
-        if (message == null || message.getBody() == null) {
-            return null;
-        }
-        final Type type = this.getMessageType();
-        if (type instanceof Class) {
-            try {
-                Object data = gson.fromJson(new String(message.getBody()), type);
-                return (T) data;
-            } catch (JsonSyntaxException e) {
-                log.error("parse message json fail : {}", e.getMessage());
-            }
-        } else {
-            log.warn("Parse msg error. {}", message);
-        }
-        return null;
-    }
-
-    /**
-     * 解析消息类型
-     *
-     * @return 消息类型
-     */
-    private Type getMessageType() {
-        Type superType = this.getClass().getGenericSuperclass();
-        if (superType instanceof ParameterizedType) {
-            return ((ParameterizedType) superType).getActualTypeArguments()[0];
-        } else {
-            // 如果没有定义泛型，解析为Object
-            return Object.class;
-//            throw new RuntimeException("Unkown parameterized type.");
-        }
     }
 }

--- a/src/main/java/com/maihaoche/starter/mq/config/MQProducerAutoConfiguration.java
+++ b/src/main/java/com/maihaoche/starter/mq/config/MQProducerAutoConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 
 import javax.annotation.PostConstruct;
 import java.util.Map;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Created by yipin on 2017/6/29.
@@ -24,6 +25,11 @@ public class MQProducerAutoConfiguration extends MQBaseAutoConfiguration {
 
     @PostConstruct
     public void init() throws Exception {
+        Map<String, Object> beans = applicationContext.getBeansWithAnnotation(MQProducer.class);
+        //对于仅仅只存在消息消费者的项目，无需构建生产者
+        if(CollectionUtils.isEmpty(beans)){
+            return;
+        }
         if(producer == null) {
 //            if(StringUtils.isEmpty(mqProperties.getProducerGroup())) {
 //                throw new RuntimeException("请在配置文件中指定消息发送方group！");
@@ -38,7 +44,6 @@ public class MQProducerAutoConfiguration extends MQBaseAutoConfiguration {
             producer.setNamesrvAddr(mqProperties.getNameServerAddress());
             producer.start();
         }
-        Map<String, Object> beans = applicationContext.getBeansWithAnnotation(MQProducer.class);
         for (Map.Entry<String, Object> entry : beans.entrySet()) {
             publishProducer(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
将AbstractMQPullConsumer及AbstractPushConsumer公共代码抽象至AbstractMQConsumer

解析消息类型的方法：gson.fromJson(new String(message.getBody()), type);返回的类型无需用一个Object data引用接收，再转为(T)data，直接返回即可

getMessageTypef方法增加断言，Type参数个数必须是1个

将rocketmq版本升级为4.1.0-incubating