### PR TITLE
fix:MessageBuilder.key()无效的问题

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ notifications:
 
 language: java
 
+jdk:
+  - openjdk8
+
 sudo: false
 script:
   - travis_retry mvn -B clean

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>com.maihaoche</groupId>
     <artifactId>spring-boot-starter-rocketmq</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 
     <scm>
         <url>https://github.com/maihaoche/rocketmq-spring-boot-starter</url>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.12</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>com.maihaoche</groupId>
     <artifactId>spring-boot-starter-rocketmq</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2-SNAPSHOT</version>
 
     <scm>
         <url>https://github.com/maihaoche/rocketmq-spring-boot-starter</url>

--- a/src/main/java/com/maihaoche/starter/mq/annotation/MQKey.java
+++ b/src/main/java/com/maihaoche/starter/mq/annotation/MQKey.java
@@ -11,9 +11,10 @@ import java.lang.annotation.*;
  * @author suclogger
  *
  */
-@Target(ElementType.FIELD)
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface MQKey {
     String prefix() default "";
+    String field();
 }

--- a/src/main/java/com/maihaoche/starter/mq/base/AbstractMQConsumer.java
+++ b/src/main/java/com/maihaoche/starter/mq/base/AbstractMQConsumer.java
@@ -34,8 +34,7 @@ public abstract class AbstractMQConsumer<T> {
         final Type type = this.getMessageType();
         if (type instanceof Class) {
             try {
-                T data = gson.fromJson(new String(message.getBody()), type);
-                return data;
+                return gson.fromJson(new String(message.getBody()), type);
             } catch (JsonSyntaxException e) {
                 log.error("parse message json fail : {}", e.getMessage());
             }

--- a/src/main/java/com/maihaoche/starter/mq/base/MessageBuilder.java
+++ b/src/main/java/com/maihaoche/starter/mq/base/MessageBuilder.java
@@ -60,7 +60,7 @@ public class MessageBuilder {
     }
 
     public Message build() {
-        String messageKey= "";
+        StringBuilder messageKey= new StringBuilder(StringUtils.isEmpty(key) ? "" : key);
         try {
             Field[] fields = message.getClass().getDeclaredFields();
             for (Field field : fields) {
@@ -70,7 +70,7 @@ public class MessageBuilder {
                         if(allFAnnos[i].annotationType().equals(MQKey.class)) {
                             field.setAccessible(true);
                             MQKey mqKey = MQKey.class.cast(allFAnnos[i]);
-                            messageKey = StringUtils.isEmpty(mqKey.prefix()) ? field.get(message).toString() : (mqKey.prefix() + field.get(message).toString());
+                            messageKey.append(StringUtils.SPACE).append(StringUtils.isEmpty(mqKey.prefix()) ? field.get(message).toString() : (mqKey.prefix() + ":" + field.get(message).toString()));
                         }
                     }
                 }
@@ -88,8 +88,8 @@ public class MessageBuilder {
         if (!StringUtils.isEmpty(tag)) {
             message.setTags(tag);
         }
-        if(StringUtils.isNotEmpty(messageKey)) {
-            message.setKeys(messageKey);
+        if(StringUtils.isNotEmpty(messageKey.toString())) {
+            message.setKeys(messageKey.toString());
         }
         if(delayTimeLevel != null && delayTimeLevel > 0 && delayTimeLevel <= DELAY_ARRAY.length) {
             message.setDelayTimeLevel(delayTimeLevel);

--- a/src/main/java/com/maihaoche/starter/mq/base/RocketMQTemplate.java
+++ b/src/main/java/com/maihaoche/starter/mq/base/RocketMQTemplate.java
@@ -1,0 +1,8 @@
+package com.maihaoche.starter.mq.base;
+
+/**
+ * @author ouyangduning
+ * @date 2020/6/11 14:26
+ */
+public class RocketMQTemplate extends AbstractMQProducer {
+}

--- a/src/main/java/com/maihaoche/starter/mq/config/MQProperties.java
+++ b/src/main/java/com/maihaoche/starter/mq/config/MQProperties.java
@@ -32,4 +32,9 @@ public class MQProperties {
      */
     private Boolean vipChannelEnabled = Boolean.TRUE;
 
+    /**
+     * 默认存在生产者
+     */
+    private Boolean existProducer = Boolean.TRUE;
+
 }

--- a/src/test/java/com/maihaoche/starter/mq/config/MQProducerAutoConfigurationTest.java
+++ b/src/test/java/com/maihaoche/starter/mq/config/MQProducerAutoConfigurationTest.java
@@ -19,6 +19,7 @@ public class MQProducerAutoConfigurationTest {
 
     private void prepareApplicationContextEmpty() {
         this.context = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(this.context, "spring.rocketmq.exist-producer:false");
         this.context.register(MQBaseAutoConfiguration.class, MQProducerAutoConfiguration.class);
         this.context.refresh();
     }
@@ -60,7 +61,9 @@ public class MQProducerAutoConfigurationTest {
 
     @After
     public void close() {
-        this.context.close();
+        if (context != null) {
+            this.context.close();
+        }
     }
 
 


### PR DESCRIPTION
[#16](https://github.com/maihaoche/rocketmq-spring-boot-starter/issues/16)
1.使用`MessageBuilder.of(msg).tag("").key("key").topic(topic).build()`，是发现`.key("key")`无论怎么设置都无效。修复后改为了，如果有`.key()`,把它作为消息的key，如果实体中还有`@MQKey`，`@MQKey`的内容拼接在其后面。
2.实体类中有多个`@MQKey("key")`时，只有最后一个字段的`@MQKey("key")`有效，感觉不是很好，改成了如果有多个`@MQKey("key")`，就把所有key的内容拼接到一起，成为消息的key。
3.为了不和之前版本混淆，版本改为了0.1.1
望及时采纳，发布到中央仓库。